### PR TITLE
feat(automation): open one PR per provider, draft when blocked

### DIFF
--- a/.github/workflows/fetch-prices.yml
+++ b/.github/workflows/fetch-prices.yml
@@ -34,17 +34,26 @@ jobs:
         with:
           python-version: '3.11'
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020   # v7.0.0
-        with:
-          node-version: '20'
+      - name: Capture base commit
+        # Every later step diffs against this instead of a moving "HEAD",
+        # since the per-provider loop below checks out a fresh branch (and
+        # therefore a new HEAD) for every provider that has a diff.
+        run: echo "BASE_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
 
       - name: Install test dependencies
         run: pip install -r requirements-dev.txt
 
-      - name: Ensure automation label exists
+      - name: Ensure automated label exists
+        if: "!inputs.dry_run"
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh label create automated --color ededed --description "Opened by the price-fetch automation" 2>/dev/null || true
+
+      - name: Ensure blocked label exists
+        if: "!inputs.dry_run"
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh label create blocked --color d73a4a --description "Plausibility gate found a hard finding; do not mark ready without reviewing" 2>/dev/null || true
 
       - name: Fetch prices
         id: fetch
@@ -66,103 +75,208 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-          if [ "$(jq '.failed | length' /tmp/fetch-summary.json)" -gt 0 ]; then
-            {
-              printf '**Failed providers:** %s\n\n' "$(jq -r '.failed | keys | join(", ")' /tmp/fetch-summary.json)"
-              jq -r '.failed | to_entries[] | "- `" + .key + "`: " + .value' /tmp/fetch-summary.json
-              echo
-            } > /tmp/failed-providers.md
+      - name: Validate required fields
+        # Scoped to the providers actually fetched this run - not every
+        # file in prices/ - so a schema drift in a hand-maintained file
+        # (or an automated provider this run didn't touch) can't fail the
+        # job and take down the PR/issue loops for everyone else. Stays
+        # blocking (no continue-on-error) for the providers it does check.
+        run: |
+          mapfile -t fetched_files < <(jq -r '.ok[] | "prices/" + . + ".json"' /tmp/fetch-summary.json)
+          if [ "${#fetched_files[@]}" -eq 0 ]; then
+            echo "No providers were fetched; nothing to validate."
           else
-            : > /tmp/failed-providers.md
+            python scripts/validate-prices.py "${fetched_files[@]}"
           fi
 
-      - name: Validate required fields
-        run: python scripts/validate-prices.py
-
       - name: Validate against schema
-        run: python -m pytest tests/test_schema.py -q
+        # Same scoping, via an env var since pytest parametrize IDs aren't
+        # picked with positional args the way validate-prices.py's are.
+        run: |
+          mapfile -t fetched < <(jq -r '.ok[]' /tmp/fetch-summary.json)
+          if [ "${#fetched[@]}" -eq 0 ]; then
+            echo "No providers were fetched; running only the schema-shape tests."
+            python -m pytest tests/test_schema.py -q -k "not test_every_automated_provider_file_validates"
+          else
+            SCHEMA_TEST_PROVIDERS="${fetched[*]}" python -m pytest tests/test_schema.py -q
+          fi
 
       - name: Plausibility check
         id: plausibility
         continue-on-error: true
         run: |
           set +e
+          # Seeded before the gate runs: a gate crash must not leave a later
+          # `gh ... --body-file` / jq lookup reading a file that doesn't exist.
           printf '## Plausibility check\n\nThe gate did not produce a report; see the job log.\n' > /tmp/report.md
-          python scripts/plausibility_check.py --report /tmp/report.md
+          printf '{}' > /tmp/verdicts.json
+          python scripts/plausibility_check.py --report /tmp/report.md --json-out /tmp/verdicts.json
           echo "exit_code=$?" >> "$GITHUB_OUTPUT"
           cat /tmp/report.md >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Detect changes
-        id: changes
-        run: |
-          if git diff --quiet -- prices/; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Open issue on hard failure
-        if: steps.plausibility.outputs.exit_code != '0' && !inputs.dry_run
+      - name: Open or update per-provider pull requests
+        if: "!inputs.dry_run"
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          title="Price fetch blocked by plausibility check"
-          cat /tmp/failed-providers.md /tmp/report.md > /tmp/issue-body.md
-          existing=$(gh issue list --state open --search "\"$title\" in:title" --json number --jq '.[0].number // empty')
-          if [ -n "$existing" ]; then
-            gh issue comment "$existing" --body-file /tmp/issue-body.md
-          else
-            gh issue create --title "$title" --body-file /tmp/issue-body.md --label automated
-          fi
-          git checkout -- prices/
-          if git ls-files --error-unmatch scripts/fetchers/data/fx_rate.json >/dev/null 2>&1; then
-            git checkout -- scripts/fetchers/data/fx_rate.json
-          fi
-
-      - name: Regenerate normalized.json
-        if: steps.plausibility.outputs.exit_code == '0' && steps.changes.outputs.changed == 'true' && !inputs.dry_run
-        run: node scripts/normalize.js normalized.json
-
-      - name: Open pull request
-        if: steps.plausibility.outputs.exit_code == '0' && steps.changes.outputs.changed == 'true' && !inputs.dry_run
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
+          set +e
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -B bot/price-update
-          git add prices/ normalized.json
-          if [ -f scripts/fetchers/data/fx_rate.json ]; then
-            git add scripts/fetchers/data/fx_rate.json
-          fi
-          git commit -m "chore: refresh provider prices"
-          git push --force-with-lease origin bot/price-update
-          {
-            echo "Automated price refresh."
-            echo
-            cat /tmp/failed-providers.md
-            cat /tmp/report.md
-            echo
-            echo "Schema validation and the plausibility check ran in the fetch job."
-            echo "A PR opened with GITHUB_TOKEN does not trigger validate-prices.yml."
-          } > /tmp/pr-body.md
-          existing=$(gh pr list --head bot/price-update --state open --json number --jq '.[0].number // empty')
-          if [ -n "$existing" ]; then
-            gh pr edit "$existing" --body-file /tmp/pr-body.md
-          else
-            gh pr create --base main --head bot/price-update \
-              --title "chore: refresh provider prices" \
-              --body-file /tmp/pr-body.md --label automated
-          fi
+
+          mapfile -t providers < <(jq -r '.ok[]' /tmp/fetch-summary.json)
+
+          for provider in "${providers[@]}"; do
+            file="prices/${provider}.json"
+
+            if git diff --quiet "$BASE_SHA" -- "$file"; then
+              continue   # fetched ok, but nothing actually changed for this provider
+            fi
+
+            # Missing from verdicts.json (e.g. the gate crashed before writing
+            # it) defaults to blocked rather than clean: absence of evidence
+            # is not evidence of safety.
+            verdict=$(jq -c --arg p "$provider" \
+              'if has($p) then .[$p] else {"hard":1,"soft":0,"blocked":true} end' \
+              /tmp/verdicts.json)
+            hard=$(printf '%s' "$verdict" | jq -r '.hard')
+            blocked=$(printf '%s' "$verdict" | jq -r '.blocked')
+
+            branch="bot/prices-${provider}"
+
+            if ! git checkout -B "$branch" "$BASE_SHA"; then
+              echo "::warning::branch checkout failed for ${provider}, skipping"
+              continue
+            fi
+
+            # A per-provider report, not the whole-run one: the whole-run
+            # report (already gated once, above, for --json-out) carries
+            # every provider's findings, and cat-ing all of it into every
+            # single PR body scales with provider count x finding count -
+            # a few hundred findings for one provider is enough to push a
+            # blocked body past GitHub's 65,536-char limit on its own, and
+            # a clean provider's PR should never show another provider's
+            # hard failures anyway. Must run before `git add`/`git commit`
+            # below: the file has to still be an uncommitted diff against
+            # HEAD (== $BASE_SHA right after the checkout above) for the
+            # gate to see it as changed at all.
+            report_file="/tmp/report-${provider}.md"
+            printf "## Plausibility check\n\nThe gate did not produce a per-provider report for %s; see the job log.\n" \
+              "$provider" > "$report_file"
+            python scripts/plausibility_check.py --prices-dir prices --provider "$provider" --report "$report_file" > /dev/null
+
+            git add "$file"
+            if ! git commit -m "chore: refresh ${provider} prices"; then
+              echo "::warning::commit failed for ${provider}, skipping"
+              git checkout "$BASE_SHA" -- "$file"
+              continue
+            fi
+            if ! git push --force-with-lease origin "$branch"; then
+              echo "::warning::push failed for ${provider}, skipping"
+              git checkout "$BASE_SHA" -- "$file"
+              continue
+            fi
+
+            body="/tmp/pr-body-${provider}.md"
+            {
+              if [ "$blocked" = "true" ]; then
+                printf "⚠️ BLOCKED — %s hard finding(s). Do not mark ready without reviewing.\n\n" "$hard"
+              fi
+              printf "Automated price refresh for \`%s\`.\n\n" "$provider"
+              cat "$report_file"
+              echo
+              echo "Schema validation and the plausibility check ran in the fetch job."
+              echo "A PR opened with GITHUB_TOKEN does not trigger validate-prices.yml."
+            } > "$body"
+
+            # Backstop, not the primary defence: the per-provider report
+            # above should already keep this well under the limit, but one
+            # provider's own findings alone can still be pathological (e.g.
+            # a fetcher regression that nulls out every instance's price).
+            if [ "$(wc -c < "$body")" -gt 65000 ]; then
+              head -c 65000 "$body" | iconv -c -f utf-8 -t utf-8 > "${body}.tmp"
+              printf '\n\n_(body truncated at 65,000 chars; see the job summary for the full report)_\n' >> "${body}.tmp"
+              mv "${body}.tmp" "$body"
+            fi
+
+            existing_json=$(gh pr list --head "$branch" --state open --json number,isDraft --jq '.[0] // empty')
+
+            if [ -n "$existing_json" ]; then
+              existing=$(printf '%s' "$existing_json" | jq -r '.number')
+              is_draft=$(printf '%s' "$existing_json" | jq -r '.isDraft')
+              gh pr edit "$existing" --body-file "$body" \
+                || echo "::warning::PR body update failed for ${provider}"
+              # Draft/ready and the blocked label are two independent facts
+              # about the same verdict, not two branches of one flip: keying
+              # the label off the draft transition left it stale whenever a
+              # human toggled ready/draft by hand between runs.
+              if [ "$blocked" = "true" ]; then
+                if [ "$is_draft" = "false" ]; then
+                  gh pr ready "$existing" --undo \
+                    || echo "::warning::draft conversion failed for ${provider}"
+                fi
+                gh pr edit "$existing" --add-label blocked \
+                  || echo "::warning::adding blocked label failed for ${provider}"
+              else
+                if [ "$is_draft" = "true" ]; then
+                  gh pr ready "$existing" \
+                    || echo "::warning::ready conversion failed for ${provider}"
+                fi
+                gh pr edit "$existing" --remove-label blocked \
+                  || echo "::warning::removing blocked label failed for ${provider}"
+              fi
+            elif [ "$blocked" = "true" ]; then
+              gh pr create --draft --base main --head "$branch" \
+                --title "chore: refresh ${provider} prices" \
+                --body-file "$body" --label automated --label blocked \
+                || echo "::warning::PR create failed for ${provider}"
+            else
+              gh pr create --base main --head "$branch" \
+                --title "chore: refresh ${provider} prices" \
+                --body-file "$body" --label automated \
+                || echo "::warning::PR create failed for ${provider}"
+            fi
+          done
+
+          # Leave the checkout matching the original base: every provider's
+          # file is either untouched or safely committed on its own branch,
+          # never sitting here as an uncommitted (dirty) change. This does
+          # NOT cover scripts/fetchers/data/fx_rate.json, which fetch_prices.py
+          # may have rewritten this run: that file is deliberately never
+          # added or committed by this loop (it isn't any one provider's
+          # file), so it can be left modified in the working tree here. The
+          # runner is destroyed at the end of the job either way.
+          git checkout "$BASE_SHA" 2>/dev/null || true
+
+      - name: Open issues for providers whose fetch failed
+        if: "!inputs.dry_run"
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set +e
+          mapfile -t failed_providers < <(jq -r '.failed | keys[]' /tmp/fetch-summary.json)
+
+          for provider in "${failed_providers[@]}"; do
+            reason=$(jq -r --arg p "$provider" '.failed[$p]' /tmp/fetch-summary.json)
+            title="Price fetch failed: ${provider}"
+            body="/tmp/issue-body-${provider}.md"
+            printf "Automated price fetch for \`%s\` failed:\n\n\`\`\`\n%s\n\`\`\`\n" "$provider" "$reason" > "$body"
+
+            existing=$(gh issue list --state open --search "\"$title\" in:title" --json number --jq '.[0].number // empty')
+            if [ -n "$existing" ]; then
+              gh issue comment "$existing" --body-file "$body"
+            else
+              gh issue create --title "$title" --body-file "$body" --label automated
+            fi
+          done
 
       - name: Open issue on total workflow failure
         if: failure() && !inputs.dry_run
         env:
           GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           title="Price fetch workflow failed"
-          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          printf 'The price-fetch workflow failed before it could produce a report (e.g. every provider failed, or a step crashed).\n\nSee the run log: %s\n' "$run_url" > /tmp/failure-body.md
+          printf 'The price-fetch workflow failed before it could produce a report (e.g. every provider failed, or a step crashed).\n\nSee the run log: %s\n' "$RUN_URL" > /tmp/failure-body.md
           existing=$(gh issue list --state open --search "\"$title\" in:title" --json number --jq '.[0].number // empty')
           if [ -n "$existing" ]; then
             gh issue comment "$existing" --body-file /tmp/failure-body.md

--- a/README.md
+++ b/README.md
@@ -55,18 +55,41 @@ documented successor requires an API key, which this project does not use.
 Every other provider file is maintained by hand and is never written to by
 automation.
 
-The workflow fetches, validates required fields, runs the schema-validation
-tests against `prices/schema.json`, then runs `scripts/plausibility_check.py`.
-If that gate passes it opens a PR; if it fails it opens an issue with the
-report and leaves `prices/` untouched. A human reviews and merges every data
-change.
+The workflow fetches all providers in one pass, validates required fields, runs
+the schema-validation tests against `prices/schema.json`, then runs
+`scripts/plausibility_check.py` once for every provider (`--json-out` gives a
+per-provider verdict alongside the human-readable report). It then opens **one
+PR per provider that actually changed**, each on its own `bot/prices-<provider>`
+branch:
+
+- A provider whose file changed and passed the gate cleanly gets a normal PR,
+  ready for review.
+- A provider whose file changed but tripped a hard finding still gets a PR —
+  as a **draft**, labelled `blocked`, with the warning and that provider's
+  findings at the top of the body. The gate's job is to make the risk
+  unmissable, not to hide the diff: reviewing a blocked PR is how you see
+  exactly what changed and decide whether to mark it ready.
+- A provider whose fetch itself failed (e.g. `gcp`'s 404s) never produces a
+  diff, so it gets no PR; instead the workflow opens (or updates) one issue
+  per failed provider.
+- A provider with no change at all gets nothing.
+
+Re-running the workflow updates each provider's existing PR in place (body,
+and a ready ⇄ draft transition if its verdict flipped) rather than opening a
+duplicate. `normalized.json` is never touched by this workflow — pushing to
+`main` under `prices/**` regenerates it separately via
+[`.github/workflows/normalize.yml`](.github/workflows/normalize.yml), so five
+per-provider PRs never fight over regenerating it themselves. A human reviews
+and merges every data change.
 
 Run it locally:
 
 ```bash
 pip install -r requirements-dev.txt
 python scripts/fetch_prices.py --provider all --dry-run
-python scripts/plausibility_check.py
+python scripts/plausibility_check.py                       # gate everything
+python scripts/plausibility_check.py --provider aws        # gate one provider
+python scripts/plausibility_check.py --json-out /tmp/verdicts.json
 ```
 
 ### Design decisions

--- a/scripts/plausibility_check.py
+++ b/scripts/plausibility_check.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 """Gate freshly fetched price files against the versions committed at HEAD.
 
-Exit code 0 = clean or soft flags only, 1 = at least one hard failure.
-A hard failure means no PR is opened; the workflow files an issue instead.
+Exit code 0 = clean or soft flags only, 1 = at least one hard failure. The
+workflow runs this once for all providers (via --json-out) and opens a
+draft PR, labelled `blocked`, for any provider with a hard failure rather
+than suppressing its PR - the exit code and --json-out verdicts drive that
+per-provider decision. --provider restricts everything to one file.
 """
 
 from __future__ import annotations
@@ -286,7 +289,7 @@ def render_report(findings: list[Finding], reverted: list[str], fx_notes: list[s
 
     hard_block: list[str] = []
     if hard:
-        hard_block = ["### Hard failures — no PR opened", "", "| Provider | Check | Detail |", "|---|---|---|"]
+        hard_block = ["### Hard failures — opens as a draft PR", "", "| Provider | Check | Detail |", "|---|---|---|"]
         included = 0
         for f in hard:
             row = f"| {f.provider} | `{f.code}` | {f.message} |"
@@ -387,12 +390,25 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--prices-dir", default=str(PRICES_DIR))
     parser.add_argument("--report", help="also write the markdown report to this path")
+    parser.add_argument(
+        "--provider",
+        help="gate only this provider's file (matched against the price file's stem); "
+             "the exit code then reflects that provider alone",
+    )
+    parser.add_argument(
+        "--json-out",
+        help="write per-provider {hard, soft, blocked} verdicts as JSON to this path, "
+             "for every provider examined - including ones with zero findings",
+    )
     args = parser.parse_args(argv)
 
     prices_dir = Path(args.prices_dir).resolve()
     findings: list[Finding] = []
     reverted: list[str] = []
     fx_notes: list[str] = []
+    # Every provider whose file was looked at this run, regardless of whether
+    # it produced a finding - the basis for --json-out's per-provider verdicts.
+    examined_providers: set[str] = set()
 
     root = Path(subprocess.run(
         ["git", "rev-parse", "--show-toplevel"],
@@ -404,6 +420,14 @@ def main(argv: list[str] | None = None) -> int:
     changed = _git_diff_paths(prices_dir, root, "d")
     deleted = _git_diff_paths(prices_dir, root, "D")
     renamed = _git_renames(prices_dir, root)
+
+    if args.provider:
+        # Restrict every query below to the one file whose stem matches
+        # --provider, so both the report and the exit code reflect it alone.
+        changed = [rel for rel in changed if Path(rel).stem == args.provider]
+        deleted = [rel for rel in deleted if Path(rel).stem == args.provider]
+        renamed = [(o, n) for o, n in renamed if Path(o).stem == args.provider]
+
     # Renames are reported through their own loop below; exclude their two
     # halves from the plain deleted/changed queries to avoid a duplicate finding.
     renamed_old_paths = {old for old, _new in renamed}
@@ -414,6 +438,7 @@ def main(argv: list[str] | None = None) -> int:
         if path.name == "schema.json":
             continue
         name = path.stem
+        examined_providers.add(name)
         old = _head_version(old_rel, root)
         if not old:
             continue
@@ -430,6 +455,7 @@ def main(argv: list[str] | None = None) -> int:
         if path.name == "schema.json":
             continue
         name = path.stem
+        examined_providers.add(name)
         old = _head_version(rel, root)
         if not old:
             continue
@@ -445,6 +471,7 @@ def main(argv: list[str] | None = None) -> int:
         if path.name == "schema.json":
             continue
         name = path.stem
+        examined_providers.add(name)
         if not path.exists():
             # Listed as changed (not a deletion) but missing on disk, e.g. a
             # dangling symlink; still needs a hard finding, not a silent skip.
@@ -502,6 +529,17 @@ def main(argv: list[str] | None = None) -> int:
     print(report)
     if args.report:
         Path(args.report).write_text(report)
+
+    if args.json_out:
+        verdicts: dict[str, dict] = {p: {"hard": 0, "soft": 0} for p in examined_providers}
+        for f in findings:
+            # setdefault, not indexing: a Finding's provider is always one we
+            # recorded in examined_providers, but falling back defensively
+            # here costs nothing and keeps this block decoupled from that guarantee.
+            verdicts.setdefault(f.provider, {"hard": 0, "soft": 0})[f.level] += 1
+        for v in verdicts.values():
+            v["blocked"] = v["hard"] > 0
+        Path(args.json_out).write_text(json.dumps(verdicts, indent=2, sort_keys=True) + "\n")
 
     return 1 if any(f.level == "hard" for f in findings) else 0
 

--- a/scripts/validate-prices.py
+++ b/scripts/validate-prices.py
@@ -2,8 +2,17 @@
 """
 Validate price JSON files against the schema.
 Exit code 0 = all valid, 1 = validation errors found.
+
+    python scripts/validate-prices.py [FILE ...]
+
+With no arguments, validates every file in prices/ (the historical
+behaviour, used by validate-prices.yml on every push/PR). Given explicit
+paths, validates only those - e.g. so a CI run only holds the providers it
+actually fetched to account, without a hand-maintained file elsewhere in
+prices/ blocking automation for providers it never touched.
 """
 
+import argparse
 import json
 import os
 import sys
@@ -54,6 +63,8 @@ def validate_price_file(filepath: str, schema: dict) -> list:
     try:
         with open(filepath) as f:
             data = json.load(f)
+    except FileNotFoundError:
+        return [f"File not found: {filepath}"]
     except json.JSONDecodeError as e:
         return [f"Invalid JSON: {e}"]
 
@@ -99,8 +110,15 @@ def validate_price_file(filepath: str, schema: dict) -> list:
     return errors
 
 
-def main():
+def main(argv=None):
     """Main entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "files", nargs="*",
+        help="specific price files to validate; defaults to every file in prices/",
+    )
+    args = parser.parse_args(argv)
+
     prices_dir = Path(__file__).parent.parent / 'prices'
     schema_path = prices_dir / 'schema.json'
 
@@ -110,11 +128,14 @@ def main():
 
     schema = load_schema(schema_path)
 
-    # Find all price files (exclude schema.json)
-    price_files = sorted([
-        f for f in prices_dir.glob('*.json')
-        if f.name != 'schema.json'
-    ])
+    if args.files:
+        price_files = sorted(Path(f) for f in args.files)
+    else:
+        # Find all price files (exclude schema.json)
+        price_files = sorted([
+            f for f in prices_dir.glob('*.json')
+            if f.name != 'schema.json'
+        ])
 
     if not price_files:
         print("❌ No price files found")

--- a/tests/test_plausibility.py
+++ b/tests/test_plausibility.py
@@ -496,3 +496,146 @@ def test_main_flags_malformed_json_as_hard_instead_of_crashing(tmp_path):
     subprocess.run(["git", "add", "prices/alpha.json"], cwd=tmp_path, check=True)
 
     assert pc.main(["--prices-dir", str(prices)]) == 1
+
+
+# --- per-provider PR restructure: --provider and --json-out ---------------
+#
+# The workflow now opens one PR per provider and must be able to gate (and
+# get a machine-readable verdict for) a single provider's file without the
+# other four providers' findings leaking into its exit code or report, plus
+# a JSON verdict file it can loop over instead of re-parsing the markdown.
+
+
+def _init_two_provider_repo(tmp_path: Path) -> Path:
+    """Like ``_init_repo``, but alpha and beta are both committed as the
+    baseline before either is dirtied - unlike bolting beta on after alpha
+    is already dirtied, which would sweep alpha's uncommitted change into
+    the "baseline" commit via ``git add -A`` and hide it from every
+    comparison that follows.
+    """
+    prices = _init_repo(tmp_path)
+    (prices / "beta.json").write_text(json.dumps({
+        "provider": "beta", "fetched_at": "2026-08-13T00:00:00Z",
+        "instances": [{"id": "b", "price_monthly": 5.0, "currency": "EUR"}],
+    }))
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "add beta"], cwd=tmp_path, check=True)
+    return prices
+
+
+def test_provider_flag_restricts_the_verdict_to_one_file(tmp_path):
+    """alpha gets a real (hard) price jump; beta's price is untouched. Gating
+    with --provider alpha must fail; gating with --provider beta must pass,
+    even though alpha's file is still sitting there broken."""
+    prices = _init_two_provider_repo(tmp_path)
+    (prices / "alpha.json").write_text(json.dumps({
+        "provider": "alpha", "fetched_at": "2026-08-14T00:00:00Z",
+        "instances": [{"id": "x", "price_monthly": 100.0, "currency": "EUR"}],
+    }))
+    subprocess.run(["git", "add", "prices/alpha.json"], cwd=tmp_path, check=True)
+
+    assert pc.main(["--prices-dir", str(prices), "--provider", "beta"]) == 0
+    assert pc.main(["--prices-dir", str(prices), "--provider", "alpha"]) == 1
+    # No --provider at all still sees both, so the beta-only pass above
+    # wasn't just alpha being clean.
+    assert pc.main(["--prices-dir", str(prices)]) == 1
+
+
+def test_provider_flag_excludes_other_providers_findings_from_the_report(tmp_path):
+    prices = _init_two_provider_repo(tmp_path)
+    (prices / "alpha.json").write_text(json.dumps({
+        "provider": "alpha", "fetched_at": "2026-08-14T00:00:00Z",
+        "instances": [{"id": "x", "price_monthly": 100.0, "currency": "EUR"}],
+    }))
+    subprocess.run(["git", "add", "prices/alpha.json"], cwd=tmp_path, check=True)
+
+    report_path = tmp_path / "report.md"
+    pc.main(["--prices-dir", str(prices), "--provider", "beta", "--report", str(report_path)])
+    report = report_path.read_text()
+    assert "alpha" not in report
+    assert "No anomalies detected" in report
+
+
+def test_json_out_is_written_on_a_clean_run_with_no_changes(tmp_path):
+    """'Write it even when the run is clean' - including the degenerate case
+    where nothing changed at all, so the verdicts dict is empty."""
+    prices = _init_repo(tmp_path)
+    json_out = tmp_path / "verdicts.json"
+
+    assert pc.main(["--prices-dir", str(prices), "--json-out", str(json_out)]) == 0
+    assert json.loads(json_out.read_text()) == {}
+
+
+def test_json_out_includes_a_provider_with_zero_findings(tmp_path):
+    """A file can genuinely change (not a fetched_at-only no-op) without
+    tripping any check - e.g. a field compare() doesn't look at. That
+    provider must still show up in --json-out with hard=0, soft=0,
+    blocked=false, not be silently absent.
+    """
+    prices = _init_repo(tmp_path)
+    data = json.loads((prices / "alpha.json").read_text())
+    data["fetched_at"] = "2026-08-14T00:00:00Z"
+    data["instances"][0]["location"] = "us"  # not checked by compare() at all
+    (prices / "alpha.json").write_text(json.dumps(data))
+    subprocess.run(["git", "add", "prices/alpha.json"], cwd=tmp_path, check=True)
+
+    json_out = tmp_path / "verdicts.json"
+    assert pc.main(["--prices-dir", str(prices), "--json-out", str(json_out)]) == 0
+
+    verdicts = json.loads(json_out.read_text())
+    assert verdicts == {"alpha": {"hard": 0, "soft": 0, "blocked": False}}
+
+
+def test_json_out_is_written_on_a_blocked_run(tmp_path):
+    prices = _init_two_provider_repo(tmp_path)
+    (prices / "alpha.json").write_text(json.dumps({
+        "provider": "alpha", "fetched_at": "2026-08-14T00:00:00Z",
+        "instances": [{"id": "x", "price_monthly": 100.0, "currency": "EUR"}],
+    }))
+    subprocess.run(["git", "add", "prices/alpha.json"], cwd=tmp_path, check=True)
+    # beta gets a real, non-fetched_at-only change that trips no check, so
+    # it's "examined" with zero findings rather than absent or reverted.
+    beta_data = json.loads((prices / "beta.json").read_text())
+    beta_data["instances"][0]["location"] = "us"
+    (prices / "beta.json").write_text(json.dumps(beta_data))
+    subprocess.run(["git", "add", "prices/beta.json"], cwd=tmp_path, check=True)
+
+    json_out = tmp_path / "verdicts.json"
+    assert pc.main(["--prices-dir", str(prices), "--json-out", str(json_out)]) == 1
+
+    verdicts = json.loads(json_out.read_text())
+    assert verdicts["alpha"]["hard"] >= 1
+    assert verdicts["alpha"]["blocked"] is True
+    assert verdicts["beta"] == {"hard": 0, "soft": 0, "blocked": False}
+
+
+def test_json_out_and_provider_flag_combine_to_one_entry(tmp_path):
+    prices = _init_two_provider_repo(tmp_path)
+    (prices / "alpha.json").write_text(json.dumps({
+        "provider": "alpha", "fetched_at": "2026-08-14T00:00:00Z",
+        "instances": [{"id": "x", "price_monthly": 100.0, "currency": "EUR"}],
+    }))
+    subprocess.run(["git", "add", "prices/alpha.json"], cwd=tmp_path, check=True)
+    beta_data = json.loads((prices / "beta.json").read_text())
+    beta_data["instances"][0]["location"] = "us"
+    (prices / "beta.json").write_text(json.dumps(beta_data))
+    subprocess.run(["git", "add", "prices/beta.json"], cwd=tmp_path, check=True)
+
+    json_out = tmp_path / "verdicts.json"
+    pc.main(["--prices-dir", str(prices), "--provider", "beta", "--json-out", str(json_out)])
+
+    assert json.loads(json_out.read_text()) == {"beta": {"hard": 0, "soft": 0, "blocked": False}}
+
+
+def test_default_behaviour_without_the_new_flags_is_unchanged(tmp_path):
+    """Regression guard: introducing --provider/--json-out must not alter
+    the existing no-flags exit code or report for a run that never sets
+    them, e.g. by a stray verdicts computation running unconditionally."""
+    prices = _init_repo(tmp_path)
+    (prices / "alpha.json").write_text(json.dumps({
+        "provider": "alpha", "fetched_at": "2026-08-14T00:00:00Z",
+        "instances": [{"id": "x", "price_monthly": 100.0, "currency": "EUR"}],
+    }))
+    subprocess.run(["git", "add", "prices/alpha.json"], cwd=tmp_path, check=True)
+
+    assert pc.main(["--prices-dir", str(prices)]) == 1

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,4 +1,7 @@
 import json
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 import jsonschema
@@ -6,6 +9,15 @@ import pytest
 
 ROOT = Path(__file__).parent.parent
 SCHEMA = json.loads((ROOT / "prices" / "schema.json").read_text())
+
+_ALL_AUTOMATED_PROVIDERS = ["aws", "gcp", "azure", "ovh", "scaleway", "atlanticcloud"]
+# Space-separated override, e.g. from a CI run that only fetched some
+# providers this pass - a hand-maintained or untouched automated-provider
+# file elsewhere must not be able to block that run. Unset (the default,
+# including every direct `pytest tests/test_schema.py` invocation) keeps
+# testing the full list.
+_env = os.environ.get("SCHEMA_TEST_PROVIDERS")
+PROVIDERS_TO_TEST = _env.split() if _env else _ALL_AUTOMATED_PROVIDERS
 
 
 def test_schema_describes_the_fx_block():
@@ -30,7 +42,25 @@ def test_a_payload_with_an_fx_block_validates():
     jsonschema.validate(payload, SCHEMA)
 
 
-@pytest.mark.parametrize("name", ["aws", "gcp", "azure", "ovh", "scaleway", "atlanticcloud"])
+@pytest.mark.parametrize("name", PROVIDERS_TO_TEST)
 def test_every_automated_provider_file_validates(name):
     payload = json.loads((ROOT / "prices" / f"{name}.json").read_text())
     jsonschema.validate(payload, SCHEMA)
+
+
+# PROVIDERS_TO_TEST is fixed at module import time, so exercising the env
+# var's effect on *this* process wouldn't prove anything - it's read once,
+# before any test runs. Spawn a subprocess instead, matching how the
+# workflow actually sets it.
+def test_schema_test_providers_env_var_restricts_collection():
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "tests/test_schema.py", "--collect-only", "-q"],
+        cwd=ROOT, capture_output=True, text=True,
+        env={**os.environ, "SCHEMA_TEST_PROVIDERS": "ovh"},
+    )
+    assert "test_every_automated_provider_file_validates[ovh]" in result.stdout
+    assert "test_every_automated_provider_file_validates[aws]" not in result.stdout
+    # The two non-parametrized schema-shape tests are never scoped by this
+    # env var - they don't depend on which providers were fetched.
+    assert "test_schema_describes_the_fx_block" in result.stdout
+    assert "test_a_payload_with_an_fx_block_validates" in result.stdout

--- a/tests/test_validate_prices.py
+++ b/tests/test_validate_prices.py
@@ -1,0 +1,73 @@
+"""Tests for scripts/validate-prices.py's optional file-list argument.
+
+The module lives at a hyphenated path (not a valid Python identifier), so
+it's loaded via importlib rather than a normal import - mirroring how the
+workflow itself invokes it: as a script, not a package.
+"""
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "validate_prices", Path(__file__).parent.parent / "scripts" / "validate-prices.py"
+)
+vp = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(vp)
+
+
+def _valid_payload(provider: str) -> dict:
+    return {
+        "provider": provider,
+        "fetched_at": "2026-08-13T00:00:00Z",
+        "manual": False,
+        "instances": [{
+            "id": "a", "name": "A", "vcpu": 1, "ram_gb": 1, "disk_gb": 10,
+            "price_monthly": 5.0, "currency": "EUR",
+        }],
+    }
+
+
+def test_default_no_args_validates_every_file_in_prices_dir(capsys):
+    """Regression guard: the CI push/PR workflow (validate-prices.yml) still
+    calls this with no arguments and expects it to sweep the whole prices/
+    directory - that behaviour must survive the new opt-in scoping."""
+    with pytest.raises(SystemExit) as exc:
+        vp.main([])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "Validating" in out and "price files against schema" in out
+
+
+def test_explicit_files_restrict_validation_to_those_files(tmp_path, capsys):
+    """A hand-maintained file elsewhere in prices/ must not be able to block
+    a CI run that only names the providers it actually fetched."""
+    good = tmp_path / "aws.json"
+    good.write_text(json.dumps(_valid_payload("aws")))
+    bad = tmp_path / "contabo.json"
+    bad.write_text(json.dumps({"provider": "contabo"}))  # missing required keys
+
+    with pytest.raises(SystemExit) as exc:
+        vp.main([str(good)])
+    assert exc.value.code == 0  # contabo.json was never named, so its errors don't count
+
+    out = capsys.readouterr().out
+    assert "aws.json" in out
+    assert "contabo.json" not in out
+
+
+def test_explicit_bad_file_still_fails(tmp_path):
+    bad = tmp_path / "contabo.json"
+    bad.write_text(json.dumps({"provider": "contabo"}))
+
+    with pytest.raises(SystemExit) as exc:
+        vp.main([str(bad)])
+    assert exc.value.code == 1
+
+
+def test_a_missing_named_file_is_a_validation_error_not_a_crash(tmp_path):
+    missing = tmp_path / "nope.json"
+    with pytest.raises(SystemExit) as exc:
+        vp.main([str(missing)])
+    assert exc.value.code == 1


### PR DESCRIPTION
Follows up on the first live run of the price-fetch automation, which exposed two flaws.

**One blocked provider blocked everything.** OVH's USD→EUR currency change hard-failed the gate, which suppressed the PR for all five providers — AWS's 22 new Graviton instances and Scaleway's 37 new offers couldn't land either.

**A blocked run hid the evidence.** It filed an issue with a text report describing changes you couldn't see without reproducing the data locally. The diff is the review surface; the gate should make risk unmissable, not withhold it.

## New behaviour, per provider

| Situation | Result |
|---|---|
| Changed, gate clean | Normal PR, ready for review |
| Changed, gate blocked | **Draft** PR, `blocked` label, findings at top of body |
| Fetch failed (`gcp`) | No diff to show → one issue for that provider |
| Nothing changed | Nothing |

Draft status is the guard — GitHub won't merge a draft without an explicit "Ready for review" click. Issues now cover only cases with no diff to show.

## Notable

- `plausibility_check.py` gains `--provider` and `--json-out`. Bodies render per provider — the combined report hit **98,140 chars** on a large blocked run against GitHub's 65,536 limit, which would have 422'd and produced no PR *and* no warning. Now 36,778, with a truncation backstop.
- Pre-loop validation is scoped to fetched providers. It previously iterated all 34 price files, so a hand-edited `contabo.json` could fail the job and skip every PR — the same all-or-nothing failure from a different trigger.
- Every `gh` mutation is guarded and annotates on failure; an unguarded one would leave a pushed branch with no PR.
- `normalize.js` dropped from this workflow — `normalize.yml` already regenerates `normalized.json` on push to main, and five PRs touching it would only conflict.

## Verification

140 tests pass. The workflow's shell body was extracted verbatim and executed against a throwaway repo with a real bare remote and a stubbed `gh`, covering all four behaviour rows, all four ready↔draft transitions, `gh`-failure isolation, no-diff skip, and gate-crash-defaults-to-blocked. Each `bot/prices-<provider>` branch was confirmed to contain exactly one file, with no cross-provider leakage.

## Known follow-up

A brand-new provider's file is untracked on first fetch, and `git diff` cannot see untracked files — so it would silently get no PR. Predates this change; worth fixing before adding a seventh provider.