### PR TITLE
chore(fetchers): unregister gcp, its price source was withdrawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,14 @@ Data source for [eucloudcost.com](https://www.eucloudcost.com)
 Five providers are refreshed automatically every Friday by
 [`.github/workflows/fetch-prices.yml`](.github/workflows/fetch-prices.yml):
 `aws`, `azure`, `ovh`, `scaleway`, `atlanticcloud`. They are the providers
-with public, unauthenticated pricing APIs. `gcp` is also registered but is
-currently failing on every run: its public pricing JSON was withdrawn and its
-documented successor requires an API key, which this project does not use.
-Every other provider file is maintained by hand and is never written to by
-automation.
+with public, unauthenticated pricing APIs. Every other provider file is
+maintained by hand and is never written to by automation.
+
+`prices/gcp.json` is no longer refreshed. Google withdrew the public pricing
+JSON it was built from, and the documented successor requires an API key,
+which this project does not use. The existing data stays but is frozen; the
+fetcher remains in the tree and under test, so re-enabling it means updating
+one URL if a public endpoint reappears.
 
 The workflow fetches all providers in one pass, validates required fields, runs
 the schema-validation tests against `prices/schema.json`, then runs

--- a/scripts/fetchers/__init__.py
+++ b/scripts/fetchers/__init__.py
@@ -4,13 +4,16 @@ Each provider module exposes ``fetch(ctx) -> dict`` returning a payload that
 conforms to ``prices/schema.json``.
 """
 
-from . import atlanticcloud, aws, azure, gcp, ovh, scaleway
+from . import atlanticcloud, aws, azure, ovh, scaleway
 
+# gcp is deliberately absent: its public price JSON was withdrawn and the
+# documented successor needs an API key, which this project does not use.
+# scripts/fetchers/gcp.py is kept and still tested - only the source URL died,
+# so re-registering is a one-line change if a public endpoint reappears.
 REGISTRY = {
     "atlanticcloud": atlanticcloud.fetch,
     "aws": aws.fetch,
     "azure": azure.fetch,
-    "gcp": gcp.fetch,
     "ovh": ovh.fetch,
     "scaleway": scaleway.fetch,
 }

--- a/scripts/fetchers/gcp.py
+++ b/scripts/fetchers/gcp.py
@@ -1,4 +1,10 @@
-"""GCP Compute Engine on-demand pricing (europe-west1)."""
+"""GCP Compute Engine on-demand pricing (europe-west1).
+
+Not registered in REGISTRY: the source URL below now 404s and GCP's documented
+successor, the Cloud Billing Catalog API, requires an API key. The parsing
+logic is unaffected and still covered by tests, so if a public unauthenticated
+endpoint reappears, updating the URL and re-adding the registry entry is enough.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
`gcp` has failed on every automated run since the feature went live, filing a `Price fetch failed: gcp` issue each time.

The cause is upstream, not ours: Google withdrew the public pricing JSON `gcp.py` reads (`gstatic.com/cloud-site-ux/pricing/data/gcp-compute.json` → 404), and the documented successor, the Cloud Billing Catalog API, returns `403 PERMISSION_DENIED` without an API key. This project is scoped to public, unauthenticated endpoints, so GCP no longer qualifies.

## What changes

- `gcp` removed from `REGISTRY` — the recurring issue stops, and the run summary becomes honest: **five providers, `"failed": {}`**
- `prices/gcp.json` **kept**. The data is frozen, not deleted, and the README says so plainly rather than letting it look current.
- `scripts/fetchers/gcp.py` **kept and still under test** (14 tests). Only the URL died; the parsing logic is fine. Re-enabling is one URL plus one registry line.
- `USD_PROVIDERS` still lists `gcp` — that describes its source currency, which hasn't changed, and keeps re-enabling a one-liner.

## Verification

140 tests pass. `--provider all --dry-run` returns `"failed": {}` with all five providers OK. `--provider gcp` now errors with the valid list rather than failing at fetch time.